### PR TITLE
ops-682-add-york-colors

### DIFF
--- a/packages/york-core/src/styles/colors.js
+++ b/packages/york-core/src/styles/colors.js
@@ -1,0 +1,12 @@
+export default {
+  elfGreen: '#20A052',
+  gorse: '#FAE12E',
+  persianRed: '#D13737',
+  white: '#FFFFFF',
+  whiteSmoke: '#F8F8F8',
+  gainsboro: '#D9D9D9',
+  darkGrey: '#A6A6A6',
+  mortar: '#595959',
+  black: '#000000',
+  nero: '#222222',
+};


### PR DESCRIPTION
[Task](https://qleanru.atlassian.net/browse/OPS-682)

Add colors to `york-core` with real RGB colors name