### PR TITLE
hotfix-rn-button

### DIFF
--- a/packages/york-react-native/src/components/Button/README.md
+++ b/packages/york-react-native/src/components/Button/README.md
@@ -23,21 +23,20 @@ const ExampleComponent = () => {
 
   return (
     <>
-      <View>
+      <Example.InputGroup>
         <Example.Checkbox
           value={isDisabled}
           onChange={() => setIsDisabled(!isDisabled)}
         >
           isDisabled
         </Example.Checkbox>
-        <Separator width={2} />
         <Example.Checkbox
           value={isSubmitting}
           onChange={() => setIsSubmitting(!isSubmitting)}
         >
           isSubmitting
         </Example.Checkbox>
-      </View>
+      </Example.InputGroup>
       <Example.Showcase withVerticalPadding>
         {whiteBackdropRanks.map(rank => (
           <StyledShowcaseItem key={rank} title={`Rank ${rank}`}>

--- a/packages/york-react-native/src/components/Button/index.js
+++ b/packages/york-react-native/src/components/Button/index.js
@@ -94,6 +94,9 @@ const style = StyleSheet.create({
     borderRadius: 4,
     borderWidth: 1,
     borderColor: colors.transparent,
+    paddingHorizontal: 15,
+  },
+  overlay: {
     position: 'absolute',
     top: 0,
     left: 0,
@@ -173,12 +176,13 @@ const Button = ({
     <TouchableOpacity
       disabled={isDisabled || isSubmitting}
       activeOpacity={0.8}
-      style={[style.container, style[size], withShadow && style.shadow]}
+      style={[style.container, withShadow && style.shadow]}
       {...props}
     >
       <Animated.View
         style={[
           style.content,
+          style[size],
           style[preset],
           {
             opacity: opacity.interpolate({
@@ -198,6 +202,7 @@ const Button = ({
       <Animated.View
         style={[
           style.content,
+          style.overlay,
           style[`${preset}Disabled`],
           {
             opacity: opacity.interpolate({

--- a/packages/york-web/src/components/simple/Button/index.js
+++ b/packages/york-web/src/components/simple/Button/index.js
@@ -176,7 +176,7 @@ const getCss = props => {
     outline: none;
     user-select: none;
     box-sizing: border-box;
-    padding: 0 ${sizes[2]}px;
+    padding: 0 ${sizes[3]}px;
     transition: ${transitions.short};
     height: ${getHeight(size)};
     width: 100%;


### PR DESCRIPTION
Исправлен баг с выравниванием кнопок по содержимому. Убрал абсолютное позиционирование у заднего слоя с контентом и добавил обоим слоям горизонтальный паддинг.