### PR TITLE
tech-1117-rn-button-title

### DIFF
--- a/packages/york-react-native/docs/fontFamily.md
+++ b/packages/york-react-native/docs/fontFamily.md
@@ -1,6 +1,6 @@
 `import { fontFamily, fontFamilyBold } from '@qlean/york-react-native'`
 
-Константа со значением `font-family`, которое используется в проекте.
+Константа со значением `fontFamily`, которое используется в проекте.
 
 ```js
 import { Text, Separator, fontFamily, fontFamilyBold } from '@qlean/york-react-native'

--- a/packages/york-react-native/docs/fontFamily.md
+++ b/packages/york-react-native/docs/fontFamily.md
@@ -1,0 +1,12 @@
+`import { fontFamily, fontFamilyBold } from '@qlean/york-react-native'`
+
+Константа со значением `font-family`, которое используется в проекте.
+
+```js
+import { Text, Separator, fontFamily, fontFamilyBold } from '@qlean/york-react-native'
+;<>
+  <Text>{fontFamily}</Text>
+  <Separator/>
+  <Text>{fontFamilyBold}</Text>
+</>
+```

--- a/packages/york-react-native/docs/fontFamily.md
+++ b/packages/york-react-native/docs/fontFamily.md
@@ -1,12 +1,11 @@
 `import { fontFamily, fontFamilyBold } from '@qlean/york-react-native'`
 
-Константа со значением `fontFamily`, которое используется в проекте.
+Константа со значением `fontFamily`, которое используется в проекте. Для жирного начертания используется `fontFamilyBold`, так как `react-native` не поддерживает `fontWeight` для кастомных шрифтов.
 
 ```js
 import { Text, Separator, fontFamily, fontFamilyBold } from '@qlean/york-react-native'
 ;<>
-  <Text>{fontFamily}</Text>
-  <Separator/>
-  <Text>{fontFamilyBold}</Text>
+  <Text>{fontFamily}, {fontFamilyBold}</Text>
+  <Text></Text>
 </>
 ```

--- a/packages/york-react-native/docs/sizes.md
+++ b/packages/york-react-native/docs/sizes.md
@@ -1,0 +1,20 @@
+`import { uiPoint, sizes } from '@qlean/york-react-native'`
+
+`uiPoint` это пункт интерфейсной сетки, все элементы интерфейса и все оступы должны быть кратны ему. Сейчас он равен 5 [пунктам]. Объект `sizes` аналогичен `sizes` из `york-core`, но возвращает все допустимые оступы сразу в пунктах, уже переменоженными на `uiPoint`.
+
+Все размеры и оступы следует задавать через `sizes[n]` или, по согласованию с дизайнером, через `uiPoint * n`.
+
+Также, отступы между элементами можно задавать через компонент `<Separator/>`, который использует ту же сетку размеров.
+
+```js
+import styled from 'styled-components'
+import { Example } from '@qlean/york-web'
+import { sizes } from '@qlean/york-react-native'
+
+const StyledBox = styled(Example.Box)`
+  width: ${sizes[16]}px;
+  height: ${sizes[8]}px;
+`
+
+;<StyledBox>16 x 8</StyledBox>
+```

--- a/packages/york-react-native/src/components/Button/README.md
+++ b/packages/york-react-native/src/components/Button/README.md
@@ -18,7 +18,8 @@ const ExampleComponent = () => {
   const buttonProps = {
     isDisabled,
     isSubmitting,
-    onClick: () => {},
+    name: 'example',
+    onPress: () => {},
   }
 
   return (
@@ -40,9 +41,7 @@ const ExampleComponent = () => {
       <Example.Showcase withVerticalPadding>
         {whiteBackdropRanks.map(rank => (
           <StyledShowcaseItem key={rank} title={`Rank ${rank}`}>
-            <Button rank={rank} {...buttonProps}>
-              White Backdrop
-            </Button>
+            <Button title="White Backdrop" rank={rank} {...buttonProps}/>
           </StyledShowcaseItem>
         ))}
       </Example.Showcase>
@@ -53,18 +52,14 @@ const ExampleComponent = () => {
             title={`Rank ${rank}`}
             titleProps={{ color: 'white' }}
           >
-            <Button rank={rank} backdropColor="dark" {...buttonProps}>
-              Dark Backdrop
-            </Button>
+            <Button title="Dark Backdrop" rank={rank} backdropColor="dark" {...buttonProps}/>
           </StyledShowcaseItem>
         ))}
       </Example.Showcase>
       <Example.Showcase backgroundColor="yellow" withVerticalPadding>
         {lightBackdropRanks.map(rank => (
           <StyledShowcaseItem key={rank} title={`Rank ${rank}`}>
-            <Button rank={rank} backdropColor="light" {...buttonProps}>
-              Light Backdrop
-            </Button>
+            <Button title="Light Backdrop" rank={rank} backdropColor="light" {...buttonProps}/>
           </StyledShowcaseItem>
         ))}
       </Example.Showcase>

--- a/packages/york-react-native/src/components/Button/index.js
+++ b/packages/york-react-native/src/components/Button/index.js
@@ -138,7 +138,7 @@ const style = StyleSheet.create({
  * Первый отражает важность кнопки на экране, а второй отвечает за цвет подложки.
  */
 const Button = ({
-  children,
+  title,
   isDisabled,
   isSubmitting,
   size,
@@ -146,6 +146,8 @@ const Button = ({
   backdropColor,
   withShadow,
   Icon,
+  name,
+  onPress,
   ...props
 }) => {
   if (
@@ -165,12 +167,14 @@ const Button = ({
     duration: 100,
   })
   const preset = `${backdropColor}${rank}`
-  const buttonText = isSubmitting ? 'Подождите...' : children
+  const buttonText = isSubmitting ? 'Подождите...' : title
   return (
     <TouchableOpacity
+      onPress={onPress}
       disabled={isDisabled || isSubmitting}
       activeOpacity={0.8}
       style={[style.container, withShadow && style.shadow]}
+      testID={name}
       {...props}
     >
       <Animated.View
@@ -232,6 +236,8 @@ Button.defaultProps = {
 }
 
 Button.propTypes = {
+  /** Текст на кнопке. */
+  title: PropTypes.string.isRequired,
   /** Делает кнопку недоступной для нажатия. */
   isDisabled: PropTypes.bool.isRequired,
   /** Заменяет текст кнопки на лоадер и делает недоступной для нажатия */
@@ -246,8 +252,10 @@ Button.propTypes = {
   withShadow: PropTypes.bool,
   /** Иконка слева от текста. */
   Icon: PropTypes.element,
-  /** Текст на кнопке. */
-  children: PropTypes.string.isRequired,
+  /** Имя кнопки, используется в автотестах в качестве testID */
+  name: PropTypes.string.isRequired,
+  /** Коллбек, вызываемый по нажатию. Автоматически отключается, если `isDisabled` или `isSubmitting` заданы как `true`. */
+  onPress: PropTypes.func.isRequired,
 }
 
 export default Button

--- a/packages/york-react-native/src/components/index.js
+++ b/packages/york-react-native/src/components/index.js
@@ -1,0 +1,3 @@
+export { default as Button } from './Button'
+export { default as Text } from './Text'
+export { default as Separator } from './Separator'

--- a/packages/york-react-native/src/index.js
+++ b/packages/york-react-native/src/index.js
@@ -1,6 +1,3 @@
-// eslint-disable-next-line import/prefer-default-export
-export { default as Button } from './components/Button'
-export { default as Text } from './components/Text'
-export { default as Separator } from './components/Separator'
-
-export { useAnimation } from './utils/hooks'
+export * from './components'
+export * from './utils/hooks'
+export * from './utils/styles'

--- a/packages/york-styleguide/styleguide.config.js
+++ b/packages/york-styleguide/styleguide.config.js
@@ -109,11 +109,28 @@ module.exports = {
       name: 'york-react-native',
       description: `Версия ${yorkReactNativePackage.version}`,
       content: '../york-react-native/README.md',
-      components: '../york-react-native/src/components/**/*.js',
       sections: [
         {
-          name: 'hooks',
-          content: '../york-react-native/docs/hooks.md',
+          name: 'components',
+          components: '../york-react-native/src/components/**/*.js',
+        },
+        {
+          name: 'utils',
+          description: 'Утилиты и константы',
+          sections: [
+            {
+              name: 'fontFamily',
+              content: '../york-react-native/docs/fontFamily.md',
+            },
+            {
+              name: 'hooks',
+              content: '../york-react-native/docs/hooks.md',
+            },
+            {
+              name: 'sizes',
+              content: '../york-react-native/docs/sizes.md',
+            },
+          ],
         },
       ],
     },


### PR DESCRIPTION
### Задача [Jira](https://qleanru.atlassian.net/browse/TECH-1117)

- добавил экспорт утилзов
- добавил немного документации
- сделал более локальные импорты
- добавил обязательный `onPress` на кнопку, который раньше неявно передавался в `{...props}` для `TouchableOpacity`
- добавил проп `name`, который прокидывается в `testID`
- заменил `children` на `title` в кнопке

Мотивация замены `children` на `title`:
- мы осознанно хотим видеть внутри кнопки только строку
- дефолтный eslint конфиг ругается, если добавлять текст не в компонент `Text`
- дети вида `{foo} {bar}` являются не строкой, а массивом
- нативная кнопка из `react-native` использует проп `title` — https://facebook.github.io/react-native/docs/button#title