### PR TITLE
hotfix-header-2

### DIFF
--- a/packages/york-react-native/src/components/Header/index.js
+++ b/packages/york-react-native/src/components/Header/index.js
@@ -110,7 +110,7 @@ export default function Header({
         <Text style={[styles.text, styles.title]} numberOfLines={1}>
           {title}
         </Text>
-        {caption && (
+        {Boolean(caption) && (
           <Text
             style={styles.text}
             preset="captionSmall"


### PR DESCRIPTION
Строки не рендерятся вне `Text`.