### PR TITLE
hotfix-tooltip-semantic

### DIFF
--- a/packages/york-web/src/components/simple/Tooltip/index.js
+++ b/packages/york-web/src/components/simple/Tooltip/index.js
@@ -36,7 +36,7 @@ const StyledTooltipContent = styled.div`
   border-radius: ${borderRadiuses.medium};
 `
 
-const StyledTooltipPointer = styled.div`
+const StyledTooltipPointer = styled.span`
   position: absolute;
   transform: translateX(-50%) rotate(45deg);
   width: ${pointerSize}px;


### PR DESCRIPTION
Окно с подсказкой имеет тег `div`, что семантически прибивает его использование только в блочных элементах. Например, если тултип находится в теге `p`, то в консоль свалится куча ошибок.

![image](https://user-images.githubusercontent.com/17547664/62718925-79aa7200-ba0f-11e9-9fad-904ad75950bd.png)

Учитывая, что он `position: absolute;`, то это изменение никак не затронет визуал, зато, сделает его более семантически правильным, и возможность использовать в инлайновых тегах.

PS не работал ранее с монорепами, если есть какие-то спец правила по работе с ним, то с удовольствием о них узнаю
