### PR TITLE
hotfix-tooltip-lineheight

### DIFF
--- a/packages/york-web/src/components/simple/Tooltip/index.js
+++ b/packages/york-web/src/components/simple/Tooltip/index.js
@@ -31,6 +31,7 @@ const StyledTooltipContainer = styled.span`
 `
 
 const StyledTooltipContent = styled.span`
+  display: flex;
   padding: ${sizes[4]}px;
   background-color: ${colors.black};
   border-radius: ${borderRadiuses.medium};

--- a/packages/york-web/src/components/simple/Tooltip/index.js
+++ b/packages/york-web/src/components/simple/Tooltip/index.js
@@ -30,11 +30,16 @@ const StyledTooltipContainer = styled.span`
   z-index: ${zIndexes.dropdown};
 `
 
+/**
+ * `line-height: 0;` используется для сброса наследование, без него, блок начинает занимать
+ * значительно больше места. Более подробное описание этого эффекта, можно прочитать тут:
+ * https://stackoverflow.com/questions/11829393/why-is-the-spans-line-height-is-useless
+ */
 const StyledTooltipContent = styled.span`
-  display: flex;
   padding: ${sizes[4]}px;
   background-color: ${colors.black};
   border-radius: ${borderRadiuses.medium};
+  line-height: 0;
 `
 
 const StyledTooltipPointer = styled.span`


### PR DESCRIPTION
Возвращаясь к проблеме line-height в тултипе

![image](https://user-images.githubusercontent.com/17547664/62779448-f2670800-babb-11e9-85e2-fa01735f8d77.png)

Так получается, что при использовании, мне приходится специально оборачивать его, и сбрасывать line-height с тем значением, которое я буду использовать внутри line-height.

Я нахожу такое поведение не правильным, мне кажется, что внутренности тултипа должны зависеть ТОЛЬКО от того, что мы прокидываем внутрь него, а не наследовать что-то извне.

Проблема эта возникает, из-за неправильной композиции элементов, она изложена в следующей статье:
https://stackoverflow.com/questions/11829393/why-is-the-spans-line-height-is-useless

иллюстрация, которая показывает проблему (обратите внимание на div, он занимает значительно большую высоту, нежели сумма трех спанов внутри него):

![image](https://user-images.githubusercontent.com/17547664/62779041-ac5d7480-baba-11e9-97f1-9e03a95f4824.png)

Возможные решения:

1. избавиться от `StyledTooltipContent`, и рендерить контент в `StyledTooltipContainer`, но там дохрена логики, быстро не пофиксить
2. сбросить эти каскадные наследования флеком (в этом пуллреквете)


