### PR TITLE
hotfix-link

### DIFF
--- a/packages/york-web/src/components/primitive/Link/README.md
+++ b/packages/york-web/src/components/primitive/Link/README.md
@@ -1,6 +1,6 @@
 ```js
 import styled from 'styled-components'
-import { Link, media } from '@qlean/york-web'
+import { Link, Text, media } from '@qlean/york-web'
 
 const StyledShowcaseItem = styled(Example.ShowcaseItem)`
   width: 33%;
@@ -20,9 +20,11 @@ const ExampleComponent = () => {
       <Example.Showcase withVerticalPadding>
         {whiteBackdropRanks.map(rank => (
           <StyledShowcaseItem key={rank} title={`Rank ${rank}`}>
-            <Link rank={rank} {...linkProps}>
-              White Backdrop
-            </Link>
+            <Text>
+              <Link rank={rank} {...linkProps}>
+                White Backdrop
+              </Link>
+            </Text>
           </StyledShowcaseItem>
         ))}
       </Example.Showcase>
@@ -33,9 +35,11 @@ const ExampleComponent = () => {
             title={`Rank ${rank}`}
             titleProps={{ color: 'white' }}
           >
-            <Link rank={rank} backdropColor="dark" {...linkProps}>
-              Dark Backdrop
-            </Link>
+            <Text>
+              <Link rank={rank} backdropColor="dark" {...linkProps}>
+                Dark Backdrop
+              </Link>
+            </Text>
           </StyledShowcaseItem>
         ))}
       </Example.Showcase>

--- a/packages/york-web/src/components/primitive/Link/index.js
+++ b/packages/york-web/src/components/primitive/Link/index.js
@@ -6,8 +6,6 @@ import { colors } from '@qlean/york-core'
 
 import { media, transitions, normalizeResponsivePreset } from 'york-web/utils'
 
-import { Text } from 'york-web/components/primitive'
-
 const presets = {
   whiteBackdropRank1: {
     color: 'green',
@@ -111,11 +109,7 @@ function Link({ href, children, ...rest }) {
   )
   return (
     <StyledLink href={href} normalizedProps={normalizedProps} {...rest}>
-      {React.isValidElement(children) ? (
-        children
-      ) : (
-        <Text color="inherit">{children}</Text>
-      )}
+      {children}
     </StyledLink>
   )
 }
@@ -132,7 +126,7 @@ Link.propTypes = {
   backdropColor: PropTypes.oneOf(['white', 'dark']),
   /** Путь ссылки */
   href: PropTypes.string.isRequired,
-  /** Содержимое ссылки. Если это элемент, то оно будет отображено как есть, иначе — обернуто в `<Text>` */
+  /** Содержимое ссылки */
   children: PropTypes.node.isRequired,
 }
 

--- a/packages/york-web/src/components/primitive/index.js
+++ b/packages/york-web/src/components/primitive/index.js
@@ -1,3 +1,4 @@
+export { default as Link } from './Link'
 export { default as Separator } from './Separator'
 export { default as Text } from './Text'
 export { default as View } from './View'

--- a/packages/york-web/src/components/simple/index.js
+++ b/packages/york-web/src/components/simple/index.js
@@ -1,5 +1,4 @@
 export { default as Button } from './Button'
 export { default as GridColumn } from './GridColumn'
 export { default as GridContainer } from './GridContainer'
-export { default as Link } from './Link'
 export { default as Tooltip } from './Tooltip'


### PR DESCRIPTION
Ссылки должны быть обернуты в текст, а не наоборот. Этот фикс позволяет ссылкам без проблем быть часть какого-то нестандартного текста.