### PR TITLE
hotfix-grid

### DIFF
--- a/packages/york-web/src/components/simple/GridContainer/index.js
+++ b/packages/york-web/src/components/simple/GridContainer/index.js
@@ -15,7 +15,10 @@ const maxWidths = {
 
 const StyledGridContainer = styled.div`
   margin: 0 auto;
-  ${media.mobile(`max-width: ${maxWidths.mobile}px;`)}
+  ${media.mobile(`
+    width: 100%;
+    max-width: ${maxWidths.mobile}px;
+  `)}
   ${media.base(`max-width: ${maxWidths.base}px;`)}
   ${media.wide(`max-width: ${maxWidths.wide}px;`)}
 `


### PR DESCRIPTION
Хочу внести изменения в `GridContainer`, в частности поставить `width: 100%` в мобильном варианте. Это связано с тем, что если контейнер оказывается внутри флекса, то он ужимается по контенту, а это практически никогда не то, что мы хотим получить от сетки, т.к. ее смысл пропадает. На десктопных версиях этого не происходит, потому что там ширина колонок фиксирована.

По идее это ничего не должно сломать, если только вы не использовали `GridContainer` каким-то очень странным образом.