### PR TITLE
hotfix-screen-2

### DIFF
--- a/packages/york-expo/App.js
+++ b/packages/york-expo/App.js
@@ -16,7 +16,7 @@ import {
 } from '@qlean/york-react-native'
 
 const styles = StyleSheet.create({
-  screen: {
+  content: {
     padding: 20,
   },
   labeledSwitch: {
@@ -124,7 +124,7 @@ export default function App() {
             />
           </Screen.Footer>
         }
-        contentContainerStyle={styles.screen}
+        contentContainerStyle={styles.content}
         withSafeAreaPaddingTop
       >
         <LabeledSwitch

--- a/packages/york-react-native/src/components/Screen/index.js
+++ b/packages/york-react-native/src/components/Screen/index.js
@@ -22,6 +22,9 @@ const sideViewContainerPadding = sizes[2]
 const sideViewContainerSize = 2 * sideViewContainerPadding + sideViewSize
 
 const styles = StyleSheet.create({
+  defaultScreenStyle: {
+    backgroundColor: colors.white,
+  },
   root: {
     flex: 1,
     paddingTop: 0,
@@ -64,6 +67,12 @@ const styles = StyleSheet.create({
   },
   sideViewSpacer: {
     height: sideViewContainerSize,
+  },
+  footerContainer: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
   },
   leftView: { left: 0 },
   rightView: { right: 0 },
@@ -128,10 +137,13 @@ const Screen = ({
   style,
   ...rest
 }) => {
+  const [footerHeight, setFooterHeight] = useState(0)
   const [scrollViewHeight, setScrollViewHeight] = useState(0)
   const [contentHeight, setContentHeight] = useState(0)
   const isScrollEnabled = contentHeight > scrollViewHeight
 
+  const onFooterLayout = ({ nativeEvent }) =>
+    setFooterHeight(nativeEvent.layout.height)
   const onScrollViewLayout = ({ nativeEvent }) =>
     setScrollViewHeight(nativeEvent.layout.height)
   const onScrollViewContentSizeChange = (width, height) =>
@@ -152,13 +164,11 @@ const Screen = ({
          * Android и iOS по-разному взаимодействуют с `behavior`. Android может вести себя лучше,
          * если вообще не задавать проп, в то время как iOS - наоборот.
          */
-        {...(Platform.OS === 'ios' && { behavior: 'padding' })}
+        {...(Platform.OS === 'ios' && { behavior: 'height' })}
         style={styles.root}
       >
-        {leftView ? <SideView {...leftView} style={styles.leftView} /> : null}
-        {rightView ? (
-          <SideView {...rightView} style={styles.rightView} />
-        ) : null}
+        {leftView && <SideView {...leftView} style={styles.leftView} />}
+        {rightView && <SideView {...rightView} style={styles.rightView} />}
         <ScrollView
           {...rest}
           scrollEnabled={isScrollEnabled}
@@ -167,8 +177,13 @@ const Screen = ({
         >
           {(rightView || leftView) && <View style={styles.sideViewSpacer} />}
           {children}
+          {footer && <View style={{ height: footerHeight }} />}
         </ScrollView>
-        {footer}
+        {footer && (
+          <View style={styles.footerContainer} onLayout={onFooterLayout}>
+            {footer}
+          </View>
+        )}
       </KeyboardAvoidingView>
     </View>
   )
@@ -180,7 +195,7 @@ Screen.defaultProps = {
   footer: null,
   withSafeAreaPaddingTop: false,
   withSafeAreaPaddingBottom: true,
-  style: null,
+  style: styles.defaultScreenStyle,
 }
 
 Screen.propTypes = {

--- a/packages/york-react-native/src/components/Screen/index.js
+++ b/packages/york-react-native/src/components/Screen/index.js
@@ -22,7 +22,7 @@ const sideViewContainerPadding = sizes[2]
 const sideViewContainerSize = 2 * sideViewContainerPadding + sideViewSize
 
 const styles = StyleSheet.create({
-  defaultScreenStyle: {
+  screenBackground: {
     backgroundColor: colors.white,
   },
   root: {
@@ -152,6 +152,7 @@ const Screen = ({
   return (
     <View
       style={[
+        styles.screenBackground,
         style,
         styles.root,
         withSafeAreaPaddingTop && styles.withSafeAreaPaddingTop,
@@ -195,7 +196,7 @@ Screen.defaultProps = {
   footer: null,
   withSafeAreaPaddingTop: false,
   withSafeAreaPaddingBottom: true,
-  style: styles.defaultScreenStyle,
+  style: null,
 }
 
 Screen.propTypes = {


### PR DESCRIPTION
Пришлось спозиционировать футер абсолютно, чтобы под ним было видно контент. Это нужно для кейсов, как на скриншоте.
![image](https://user-images.githubusercontent.com/25712010/64110645-6202a700-cd8b-11e9-9bd1-7da306405c4c.png)

Также добавил белый бэкграунд по дефолту.
