### PR TITLE
new-colors

### DIFF
--- a/packages/york-core/src/styles/colors.js
+++ b/packages/york-core/src/styles/colors.js
@@ -1,11 +1,11 @@
 import * as R from 'ramda'
 
 const hexColors = {
-  green: 0x20a052ff,
-  jungle: 0x23b059ff,
-  red: 0xd13737ff,
-  blue: 0x2fafdeff,
-  yellow: 0xfae12eff,
+  green: 0x00aa64ff,
+  jungle: 0x41cd91ff,
+  red: 0xf54146ff,
+  blue: 0x2dbefaff,
+  yellow: 0xffdc46ff,
   transparent: 0x00000000,
   white: 0xffffffff,
   smoke: 0xf8f8f8ff,


### PR DESCRIPTION
Дизайнеры попросили обновить цвета. Пойдет минорным релизом.
Было / стало
<img width="1440" alt="Screenshot 2019-09-18 at 14 57 40" src="https://user-images.githubusercontent.com/25712010/65146590-e3616700-da24-11e9-9858-fd974263b71b.png">

https://www.figma.com/file/8FhFoH32WPPgjto4ksis74/Colors?node-id=23%3A0