### PR TITLE
hotfix-button

### DIFF
--- a/packages/york-web/src/components/simple/Button/index.js
+++ b/packages/york-web/src/components/simple/Button/index.js
@@ -243,6 +243,7 @@ function Button({
   )
   return (
     <StyledButton
+      type="button"
       {...rest}
       name={name}
       normalizedProps={normalizedProps}


### PR DESCRIPTION
ВНЕЗАПНО выяснил что дефолтное поведение для кнопки это `submit`. Это не ок.