### PR TITLE
hotfix-mobile-header-phone-priority

### DIFF
--- a/packages/york-web/src/components/complex/Header/MobileHeader/index.js
+++ b/packages/york-web/src/components/complex/Header/MobileHeader/index.js
@@ -190,14 +190,14 @@ export default function MobileHeader(props) {
               </StyledLogo>
             </Link>
             <Separator width={2} />
-            {selectedRegion && (
+            {selectedRegion && !phone && (
               <Region
                 items={regions}
                 selectedItem={selectedRegion}
                 onChange={onRegionChange}
               />
             )}
-            {!selectedRegion && phone && (
+            {phone && (
               <YorkLink name="phone" href={formatPhoneHref(phone)}>
                 <StyledPhoneText preset="caption">
                   {formatPhone(phone)}


### PR DESCRIPTION
### Суть
Меняем приоритет отображения номера в мобильном хедере. Если есть номер — показываем его вместо селектора региона. Выбор региона при этом остается внутри бургера. Требования маркетинга.

### Сообщение Марины [Slack](https://qlean.slack.com/archives/CNVCNBE2D/p1573211632002700?thread_ts=1573210031.001700&cid=CNVCNBE2D)