### PR TITLE
lndr-2299-fix-queue-resp

### DIFF
--- a/packages/york-core/src/fetcher/index.js
+++ b/packages/york-core/src/fetcher/index.js
@@ -8,6 +8,7 @@ const pushToFailedRequests = request =>
     failedRequests.push({ resolve, reject })
   })
     .then(token => request(token))
+    .then(getResponseBody)
     .catch(error => Promise.reject(error))
 
 const processQueue = (error, token = null) => {


### PR DESCRIPTION
Обычно, фетчер возвращает ответ, пропущенный через `getResponseBody`
Но, запросы, попавшие в очередь из-за рефреша токена, через нее не пропускаются.

В итоге, в сагу влетает не данные полученные с бека, а голый респонс от `fetch`

```
data.constructor.name === 'Response' // true
```