### PR TITLE
hotfix-react-native-input-events

### DIFF
--- a/packages/york-react-native/src/components/TextInput/index.js
+++ b/packages/york-react-native/src/components/TextInput/index.js
@@ -77,12 +77,12 @@ const TextInput = ({
         {...rest}
         testId={name}
         onChangeText={onChange}
-        onFocus={() => {
-          if (typeof onFocus === 'function') onFocus()
+        onFocus={e => {
+          if (typeof onFocus === 'function') onFocus(e)
           setIsFocused(true)
         }}
-        onBlur={() => {
-          if (typeof onBlur === 'function') onBlur()
+        onBlur={e => {
+          if (typeof onBlur === 'function') onBlur(e)
           setIsFocused(false)
         }}
         placeholderTextColor={colors.grey}

--- a/packages/york-react-native/src/components/TextInput/index.js
+++ b/packages/york-react-native/src/components/TextInput/index.js
@@ -78,11 +78,11 @@ const TextInput = ({
         testId={name}
         onChangeText={onChange}
         onFocus={e => {
-          if (typeof onFocus === 'function') onFocus(e)
+          if (onFocus) onFocus(e)
           setIsFocused(true)
         }}
         onBlur={e => {
-          if (typeof onBlur === 'function') onBlur(e)
+          if (onBlur) onBlur(e)
           setIsFocused(false)
         }}
         placeholderTextColor={colors.grey}


### PR DESCRIPTION
В коллбэки onBlur и onFocus не пробрасывались синтетические ивенты реакта, из-за этого redux-form (и скорее всего другие формы тоже) не могли правильно схендлить эти события