### PR TITLE
hotfix-react-native-textinput

### DIFF
--- a/packages/york-react-native/src/components/TextInput/index.js
+++ b/packages/york-react-native/src/components/TextInput/index.js
@@ -81,7 +81,7 @@ const TextInput = ({
           if (onFocus) onFocus(e)
           setIsFocused(true)
         }}
-        onBlur={e => {
+        onEndEditing={e => {
           if (onBlur) onBlur(e)
           setIsFocused(false)
         }}


### PR DESCRIPTION
На андроиде событие попадающее в onBlur не содержит текст, введённый в инпут. Из-за этого редакс-форма отправляет в стор пустое значение при потере фокуса. onEndEditing работает так же как onBlur, кроме того, что значение инпута всё-таки прилетает одинаково на разных платформах

https://stackoverflow.com/questions/34053315/difference-between-onendediting-and-onblur